### PR TITLE
fix: demo code error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm install ts-markdown-builder
 ```js
 import * as md from 'ts-markdown-builder';
 
-const output = joinBlocks([
+const output = md.joinBlocks([
   md.heading('Welcome to TS Markdown Builder'),
   "It's an easy to use modern markdown generator.",
   'It supports:',


### PR DESCRIPTION
This cosmetic PR fixes demo code in `README.md` - `joinBlocks` should actually be `md.joinBlocks`.