### PR TITLE
feat: `taskList`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ts-markdown-builder is a lightweight, tree-shakable TypeScript library for programmatically generating CommonMark and GFM-compliant markdown. It exposes a functional API of pure functions that return strings — no classes or special objects.
+
+## Commands
+
+```bash
+yarn test                    # Run all tests
+yarn test --watch            # Watch mode
+yarn test <path>             # Run specific test file (e.g., yarn test src/__tests__/block.test.ts)
+yarn typecheck               # Type-check without emitting
+yarn lint                    # ESLint check
+yarn lint --fix              # Auto-fix lint issues
+yarn validate                # Run typecheck + lint + test (full check)
+yarn build                   # Full build (clean + commonjs + esm + types)
+```
+
+## Architecture
+
+All source lives in `src/` with tests in `src/__tests__/`. The library is organized into functional modules:
+
+- **`block.ts`** — Block-level elements: `heading`, `blockquote`, `codeBlock`, `list`, `orderedList`, `horizontalRule`
+- **`inline.ts`** — Inline elements: `bold`, `italic`, `code`, `link`, `image`
+- **`table.ts`** — `table()` with compact/formatted modes, auto column width calculation
+- **`html.ts`** — HTML elements usable in markdown: `disclosure` (details/summary), `lineBreak`
+- **`utils.ts`** — Shared helpers: `joinBlocks`, `prefixLines`, `escape`, `maxBackticks`
+- **`index.ts`** — Barrel re-export of all public APIs and types (`TableOptions`, `DisclosureOptions`)
+
+## Build System
+
+Babel transpiles TypeScript to both CommonJS (`dist/commonjs/`) and ESM (`dist/esm/`). TypeScript compiler generates type declarations only (`dist/types/`). Bundle size is enforced at **1 kB** via size-limit.
+
+## Code Conventions
+
+- Pure functions returning strings; composable by passing one function's output as another's input
+- Optional parameters use an `options` object pattern (e.g., `heading(text, { level: 2 })`)
+- Tests use Jest with `toMatchInlineSnapshot()` for verifying markdown output
+- Prettier: single quotes, 2-space indent, trailing commas
+- Edge cases like backtick escaping in `code()`/`codeBlock()` and pipe escaping in `table()` are handled automatically

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ It supports:
 - `codeBlock(text: string, options?: { language?: string = '' })`
 - `list(items: string[])`
 - `orderedList(items: string[])`
+- `taskList(items: TaskListItem[])` - GFM task list with checkboxes (`TaskListItem: { text: string, done?: boolean }`)
 - `horizontalRule`
 
 ### Inline

--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
     "build:commonjs": "BABEL_ENV=cjs babel src --out-dir \"dist/commonjs\" --extensions .js,.ts --out-file-extension .js --source-maps --no-comments",
     "build:esm": "BABEL_ENV=esm babel src --out-dir \"dist/esm\" --extensions .js,.ts --out-file-extension .mjs  --source-maps --no-comments",
     "build:types": "tsc --project tsconfig.release.json --outDir \"dist/types\"",
+    "format": "prettier --write \"**/*.{js,ts,tsx}\"",
+    "format:check": "prettier --check \"**/*.{js,ts,tsx}\"",
+    "validate": "yarn typecheck && yarn lint && yarn test && yarn format:check",
+    "validate:fix": "yarn format && yarn lint --fix && yarn typecheck && yarn test && yarn build",
     "release": "release-it",
-    "release:beta": "release-it --preRelease=beta",
-    "validate": "yarn typecheck && yarn lint && yarn test"
+    "release:beta": "release-it --preRelease=beta"
   },
   "keywords": [
     "markdown",

--- a/scripts/test-markdown.mjs
+++ b/scripts/test-markdown.mjs
@@ -21,6 +21,7 @@ const output = md.joinBlocks([
   md.heading('Lists', { level: 2 }),
   md.list(['Item 1', 'Item 2', 'Item 3']),
   md.orderedList(['Item 1', 'Item 2', 'Item 3']),
+  md.taskList([{ text: 'Item 1' }, { text: 'Item 2', done: true }, { text: 'Item 3', done: false }]),
 
   md.heading('Blocks', { level: 2 }),
   md.blockquote('This is a blockquote.\nIt can span multiple lines.'),

--- a/src/__tests__/block.test.ts
+++ b/src/__tests__/block.test.ts
@@ -95,6 +95,35 @@ describe('horizontalRule', () => {
   });
 });
 
+describe('taskList', () => {
+  it('renders all unchecked items', () => {
+    expect(md.taskList([{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }]))
+      .toMatchInlineSnapshot(`
+      "- [ ] Item 1
+      - [ ] Item 2
+      - [ ] Item 3"
+    `);
+  });
+
+  it('renders mixed checked and unchecked items', () => {
+    expect(
+      md.taskList([
+        { text: 'Done item', done: true },
+        { text: 'Pending item', done: false },
+        { text: 'Another done', done: true },
+      ]),
+    ).toMatchInlineSnapshot(`
+      "- [x] Done item
+      - [ ] Pending item
+      - [x] Another done"
+    `);
+  });
+
+  it('defaults done to false when omitted', () => {
+    expect(md.taskList([{ text: 'No done field' }])).toBe('- [ ] No done field');
+  });
+});
+
 describe('codeBlock', () => {
   it('renders correctly', () => {
     expect(md.codeBlock('Hello, World!')).toBe('```\nHello, World!\n```');

--- a/src/block.ts
+++ b/src/block.ts
@@ -88,3 +88,23 @@ export function list(items: readonly string[]): string {
 export function orderedList(items: readonly string[]): string {
   return items.map((item, index) => `${index + 1}. ${item}`).join('\n');
 }
+
+export type TaskListItem = {
+  text: string;
+  done?: boolean;
+};
+
+/**
+ * Create a task list block.
+ *
+ * Markdown:
+ * ```
+ * - [x] Done item
+ * - [ ] Pending item
+ * ```
+ *
+ * @param items - The items of the task list.
+ */
+export function taskList(items: readonly TaskListItem[]): string {
+  return items.map((item) => `- [${item.done ? 'x' : ' '}] ${item.text}`).join('\n');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-export { horizontalRule, heading, blockquote, orderedList, list, codeBlock } from './block';
+export {
+  horizontalRule,
+  heading,
+  blockquote,
+  orderedList,
+  list,
+  codeBlock,
+  taskList,
+} from './block';
 export { code, italic, bold, link, image } from './inline';
 export { table } from './table';
 export { lineBreak, disclosure } from './html';
@@ -6,3 +14,4 @@ export { escape, joinBlocks } from './utils';
 
 export type { TableOptions } from './table';
 export type { DisclosureOptions } from './html';
+export type { TaskListItem } from './block';


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                 
  - Add `taskList()` function to generate GFM task list (checkbox) markdown                                                        
                                                                                                                                 
##   Test plan                                                                                                                      
                                                                                                                                 
  - Unit tests for unchecked items, mixed checked/unchecked, and default done value                                              
  - Run yarn validate to confirm typecheck, lint, and tests pass