### PR TITLE
feat: `strikethrough`

### DIFF
--- a/API.md
+++ b/API.md
@@ -134,6 +134,18 @@ Italic text (`*...*`).
 italic('emphasis'); // '*emphasis*'
 ```
 
+### `strikethrough(text)`
+
+GFM strikethrough text (`~~...~~`).
+
+| Parameter | Type     | Description              |
+| --------- | -------- | ------------------------ |
+| `text`    | `string` | Text to strike through   |
+
+```ts
+strikethrough('removed'); // '~~removed~~'
+```
+
 ### `code(text)`
 
 Inline code span. Backtick count and spacing adjust automatically when the text itself contains backticks.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ It supports:
 
 - `bold(text: string)`
 - `italic(text: string)`
+- `strikethrough(text: string)` - GFM strikethrough
 - `code(text: string)`
 - `link(url: string, text?: string)` - link or autolink
 - `image(url: string, text?: string)`

--- a/scripts/test-markdown.mjs
+++ b/scripts/test-markdown.mjs
@@ -32,6 +32,7 @@ const output = md.joinBlocks([
   md.list([
     md.bold('bold'),
     md.italic('Italic'),
+    md.strikethrough('Strikethrough'),
     md.code('code with `backticks` and other **stuff**'),
     md.link('https://example.com', 'link'),
     md.link('https://example.com'),

--- a/src/__tests__/inline.test.ts
+++ b/src/__tests__/inline.test.ts
@@ -12,6 +12,12 @@ describe('italic', () => {
   });
 });
 
+describe('strikethrough', () => {
+  it('renders correctly', () => {
+    expect(md.strikethrough('Hello, World!')).toBe('~~Hello, World!~~');
+  });
+});
+
 describe('code', () => {
   it('renders correctly', () => {
     expect(md.code('Hello, World!')).toBe('`Hello, World!`');

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export {
   codeBlock,
   taskList,
 } from './block';
-export { code, italic, bold, link, image } from './inline';
+export { code, italic, bold, strikethrough, link, image } from './inline';
 export { table } from './table';
 export { lineBreak, disclosure } from './html';
 export { escape, joinBlocks } from './utils';

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -23,6 +23,17 @@ export function bold(text: string): string {
 }
 
 /**
+ * Create a strikethrough text.
+ *
+ * Markdown: `~~text~~`
+ *
+ * @param text - The text to be struck through.
+ */
+export function strikethrough(text: string): string {
+  return `~~${text}~~`;
+}
+
+/**
  * Create a code text.
  *
  * Markdown: `code`


### PR DESCRIPTION
## Summary

Add `strikethrough()` inline function using GFM `~~text~~` syntax.

