### PR TITLE
feat: `taskList` simplified syntax

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,19 +99,19 @@ orderedList(items: readonly string[]): string
 ```ts
 taskList([
   { text: 'Buy milk', done: true },
-  { text: 'Write docs' },
+  'Write docs',
 ]);
 // - [x] Buy milk
 // - [ ] Write docs
 ```
 
-GFM task list with checkboxes.
+GFM task list with checkboxes. Items can be plain strings (unchecked by default) or `TaskListItem` objects.
 
 ```tsx
-taskList(items: readonly TaskListItem[]): string
+taskList(items: readonly (string | TaskListItem)[]): string
 ```
 
-- `items` — Task list items
+- `items` — Task list items (strings or `TaskListItem` objects)
 
 **`TaskListItem`**
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It supports:
 - [`codeBlock(text: string, options?: { language?: string = '' })`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#codeblock)
 - [`list(items: string[])`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#list)
 - [`orderedList(items: string[])`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#orderedlist)
-- [`taskList(items: TaskListItem[])`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#tasklist) - GFM task list with checkboxes (`TaskListItem: { text: string, done?: boolean }`)
+- [`taskList(items: (string | TaskListItem)[])`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#tasklist) - GFM task list with checkboxes (items can be strings or `{ text: string, done?: boolean }`)
 - [`horizontalRule`](https://github.com/mdjastrzebski/ts-markdown-builder/blob/main/API.md#horizontalrule)
 
 ### Inline

--- a/scripts/test-markdown.mjs
+++ b/scripts/test-markdown.mjs
@@ -21,7 +21,7 @@ const output = md.joinBlocks([
   md.heading('Lists', { level: 2 }),
   md.list(['Item 1', 'Item 2', 'Item 3']),
   md.orderedList(['Item 1', 'Item 2', 'Item 3']),
-  md.taskList([{ text: 'Item 1' }, { text: 'Item 2', done: true }, { text: 'Item 3', done: false }]),
+  md.taskList(['Item 1', { text: 'Item 2', done: true }, { text: 'Item 3', done: false }]),
 
   md.heading('Blocks', { level: 2 }),
   md.blockquote('This is a blockquote.\nIt can span multiple lines.'),

--- a/src/__tests__/block.test.ts
+++ b/src/__tests__/block.test.ts
@@ -89,15 +89,9 @@ describe('orderedList', () => {
   });
 });
 
-describe('horizontalRule', () => {
-  it('renders correctly', () => {
-    expect(md.horizontalRule).toMatchInlineSnapshot(`"---"`);
-  });
-});
-
 describe('taskList', () => {
   it('renders all unchecked items', () => {
-    expect(md.taskList([{ text: 'Item 1' }, { text: 'Item 2' }, { text: 'Item 3' }]))
+    expect(md.taskList(['Item 1', { text: 'Item 2' }, { text: 'Item 3', done: false }]))
       .toMatchInlineSnapshot(`
       "- [ ] Item 1
       - [ ] Item 2
@@ -110,17 +104,21 @@ describe('taskList', () => {
       md.taskList([
         { text: 'Done item', done: true },
         { text: 'Pending item', done: false },
+        'Pending text item',
         { text: 'Another done', done: true },
       ]),
     ).toMatchInlineSnapshot(`
       "- [x] Done item
       - [ ] Pending item
+      - [ ] Pending text item
       - [x] Another done"
     `);
   });
+});
 
-  it('defaults done to false when omitted', () => {
-    expect(md.taskList([{ text: 'No done field' }])).toBe('- [ ] No done field');
+describe('horizontalRule', () => {
+  it('renders correctly', () => {
+    expect(md.horizontalRule).toMatchInlineSnapshot(`"---"`);
   });
 });
 

--- a/src/block.ts
+++ b/src/block.ts
@@ -105,6 +105,13 @@ export type TaskListItem = {
  *
  * @param items - The items of the task list.
  */
-export function taskList(items: readonly TaskListItem[]): string {
-  return items.map((item) => `- [${item.done ? 'x' : ' '}] ${item.text}`).join('\n');
+export function taskList(items: readonly (string | TaskListItem)[]): string {
+  const result = [];
+  for (const item of items) {
+    const text = typeof item === 'string' ? item : item.text;
+    const done = typeof item === 'string' ? false : item.done;
+    result.push(`- [${done ? 'x' : ' '}] ${text}`);
+  }
+
+  return result.join('\n');
 }


### PR DESCRIPTION
## Summary

Allow for passing `string` entries to `taskList` as unchecked tasks.